### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/app/src/audioDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/audioDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -315,7 +315,7 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
                 final List<String> names = data.getStringArrayListExtra(getString(R.string.podcast_names_key));
                 final List<String> urls = data.getStringArrayListExtra(getString(R.string.podcast_urls_key));
                 // Yes, we got some podcasts from the Simple Podcatcher
-                if (names != null && names.size() > 0) {
+                if (names != null && !names.isEmpty()) {
                     // Make sure dialog does not pop up
                     hasEmptyPodcastList = false;
                     // Import all podcasts

--- a/app/src/audioDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
+++ b/app/src/audioDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
@@ -697,7 +697,7 @@ public class PlayEpisodeService extends Service implements OnPreparedListener,
         }
 
         // Alert listeners
-        if (listeners.size() > 0)
+        if (!listeners.isEmpty())
             for (PlayServiceListener listener : listeners)
                 listener.onPlaybackComplete();
     }
@@ -730,7 +730,7 @@ public class PlayEpisodeService extends Service implements OnPreparedListener,
         }
         // If there is anybody listening, alert and let them decide what to do
         // next, if not we reset and possibly stop ourselves
-        else if (listeners.size() > 0)
+        else if (!listeners.isEmpty())
             for (PlayServiceListener listener : listeners)
                 listener.onError();
         else

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/EpisodeListActivity.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/EpisodeListActivity.java
@@ -300,7 +300,7 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
                 authorizationFragment.show(getFragmentManager(), AuthorizationFragment.TAG);
             } else {
                 // We might at least be able to show special episodes
-                if (currentEpisodeSet.size() > 0)
+                if (!currentEpisodeSet.isEmpty())
                     updateEpisodeListUi();
                 else
                     episodeListFragment.showLoadFailed(code);

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
@@ -619,7 +619,7 @@ public class PlayEpisodeService extends Service implements OnPreparedListener,
 
         // If there is anybody listening, alert and let them decide what to do
         // next, if not we reset and possibly stop ourselves
-        if (listeners.size() > 0)
+        if (!listeners.isEmpty())
             for (PlayServiceListener listener : listeners)
                 listener.onPlaybackComplete();
         else
@@ -632,7 +632,7 @@ public class PlayEpisodeService extends Service implements OnPreparedListener,
 
         // If there is anybody listening, alert and let them decide what to do
         // next, if not we reset and possibly stop ourselves
-        if (listeners.size() > 0)
+        if (!listeners.isEmpty())
             for (PlayServiceListener listener : listeners)
                 listener.onError();
         else

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
@@ -242,7 +242,7 @@ public class EpisodeListFragment extends PodcatcherListFragment {
 
             // Restore checked items, if any
             boolean shouldResetAllCheckedStates = true;
-            if (checkedEpisodes != null && checkedEpisodes.size() > 0) {
+            if (checkedEpisodes != null && !checkedEpisodes.isEmpty()) {
                 getListView().clearChoices();
 
                 for (Episode episode : checkedEpisodes) {

--- a/app/src/deluxe/java/com/podcatcher/deluxe/EpisodeListActivity.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/EpisodeListActivity.java
@@ -378,7 +378,7 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
                 authorizationFragment.show(getFragmentManager(), AuthorizationFragment.TAG);
             } else {
                 // We might at least be able to show special episodes
-                if (currentEpisodeSet.size() > 0)
+                if (!currentEpisodeSet.isEmpty())
                     updateEpisodeListUi();
                 else
                     episodeListFragment.showLoadFailed(code);

--- a/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
@@ -338,7 +338,7 @@ public class EpisodeListFragment extends PodcatcherListFragment implements Reord
 
             // Restore checked items, if any
             boolean shouldResetAllCheckedStates = true;
-            if (checkedEpisodes != null && checkedEpisodes.size() > 0) {
+            if (checkedEpisodes != null && !checkedEpisodes.isEmpty()) {
                 getListView().clearChoices();
 
                 for (Episode episode : checkedEpisodes) {

--- a/app/src/main/java/com/podcatcher/deluxe/model/sync/podcare/PodcarePodcastListSyncController.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/sync/podcare/PodcarePodcastListSyncController.java
@@ -91,7 +91,7 @@ abstract class PodcarePodcastListSyncController extends PodcareBaseSyncControlle
                     final Set<String> subscriptionsRemovedLocally = getLocallyRemovedPodcastUrls();
 
                     // 2b1. Push new local subscriptions to Podcare
-                    if (subscriptionsAddedLocally.size() > 0) {
+                    if (!subscriptionsAddedLocally.isEmpty()) {
                         final List<Subscription> feedsToUpload = new ArrayList<>(subscriptionsAddedLocally.size());
 
                         for (String feed : subscriptionsAddedLocally) {
@@ -100,7 +100,7 @@ abstract class PodcarePodcastListSyncController extends PodcareBaseSyncControlle
                                 feedsToUpload.add(podcastToSubscription(podcast, Subscription.State.SUBSCRIBED));
                         }
 
-                        if (feedsToUpload.size() > 0)
+                        if (!feedsToUpload.isEmpty())
                             podcare.addSubscriptions(connectId, feedsToUpload);
                     }
 

--- a/app/src/main/java/com/podcatcher/deluxe/view/fragments/AddSuggestionFragment.java
+++ b/app/src/main/java/com/podcatcher/deluxe/view/fragments/AddSuggestionFragment.java
@@ -406,8 +406,8 @@ public class AddSuggestionFragment extends Fragment implements OnChangePodcastLi
 
             // Update view visibility
             progressView.setVisibility(View.GONE);
-            suggestionsGridView.setVisibility(filteredSuggestionList.size() > 0 ? View.VISIBLE : View.GONE);
-            suggestionsGridEmptyView.setVisibility(filteredSuggestionList.size() == 0 ? View.VISIBLE : View.GONE);
+            suggestionsGridView.setVisibility(!filteredSuggestionList.isEmpty() ? View.VISIBLE : View.GONE);
+            suggestionsGridEmptyView.setVisibility(filteredSuggestionList.isEmpty() ? View.VISIBLE : View.GONE);
         }
     }
 

--- a/app/src/videoDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/videoDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -317,7 +317,7 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
                 final List<String> names = data.getStringArrayListExtra(getString(R.string.podcast_names_key));
                 final List<String> urls = data.getStringArrayListExtra(getString(R.string.podcast_urls_key));
                 // Yes, we got some podcasts from the Simple Podcatcher
-                if (names != null && names.size() > 0) {
+                if (names != null && !names.isEmpty()) {
                     // Make sure dialog does not pop up
                     hasEmptyPodcastList = false;
                     // Import all podcasts

--- a/app/src/videoDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
+++ b/app/src/videoDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
@@ -811,7 +811,7 @@ public class PlayEpisodeService extends Service implements MediaPlayerControl,
         }
 
         // Alert listeners
-        if (listeners.size() > 0)
+        if (!listeners.isEmpty())
             for (PlayServiceListener listener : listeners)
                 listener.onPlaybackComplete();
     }
@@ -844,7 +844,7 @@ public class PlayEpisodeService extends Service implements MediaPlayerControl,
         }
         // If there is anybody listening, alert and let them decide what to do
         // next, if not we reset and possibly stop ourselves
-        else if (listeners.size() > 0)
+        else if (!listeners.isEmpty())
             for (PlayServiceListener listener : listeners)
                 listener.onError();
         else


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1155  Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Zeeshan Asghar
