### PR TITLE
Static non-final field names should comply with a naming convention

### DIFF
--- a/app/src/androidTest/java/com/podcatcher/deluxe/model/test/SuggestionImporter.java
+++ b/app/src/androidTest/java/com/podcatcher/deluxe/model/test/SuggestionImporter.java
@@ -61,7 +61,7 @@ public class SuggestionImporter extends InstrumentationTestCase {
     /**
      * String to put in JSON for missing values, use null to disable
      */
-    private static String NO_VALUE = null;
+    private static String noValue = null;
 
     /**
      * Max age of latest podcast episode. Podcasts with older episodes
@@ -218,20 +218,20 @@ public class SuggestionImporter extends InstrumentationTestCase {
 
         public JsonDummy(SuggestionImport si) {
             this.title = cleanUp(si.getName());
-            this.subtitle = si.subtitle == null || si.subtitle.length() == 0 ? NO_VALUE : si.subtitle;
+            this.subtitle = si.subtitle == null || si.subtitle.length() == 0 ? noValue : si.subtitle;
 
-            this.keywords = si.keywords == null || si.keywords.length() == 0 ? NO_VALUE : si.keywords;
+            this.keywords = si.keywords == null || si.keywords.length() == 0 ? noValue : si.keywords;
             if (si.keywords != null && si.keywords.length() > 160)
                 Log.w(TAG, "Podcast " + title + " keywords are too long!");
 
             this.feed = si.getUrl().replace("http://", "feed://");
 
-            this.logo = si.getLogoUrl() == null ? NO_VALUE : si.getLogoUrl();
+            this.logo = si.getLogoUrl() == null ? noValue : si.getLogoUrl();
             if (si.getLogoUrl() == null)
                 Log.w(TAG, "Podcast " + title + " has no logo!");
 
             this.site = si.link != null && si.link.length() > 5 ?
-                    si.link.endsWith("/") ? si.link.substring(0, si.link.length() - 1) : si.link : NO_VALUE;
+                    si.link.endsWith("/") ? si.link.substring(0, si.link.length() - 1) : si.link : noValue;
 
             if (si.getDescription() == null)
                 this.description = si.summary;

--- a/app/src/audioDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
+++ b/app/src/audioDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
@@ -392,7 +392,7 @@ public class PlayEpisodeService extends Service implements OnPreparedListener,
                     // We add some request headers to overwrite the default user
                     // agent because this is blocked by some servers
                     final HashMap<String, String> headers = new HashMap<>(2);
-                    headers.put(Podcatcher.USER_AGENT_KEY, Podcatcher.USER_AGENT_VALUE);
+                    headers.put(Podcatcher.USER_AGENT_KEY, Podcatcher.userAgentValue);
 
                     // Also set the authorization header data if needed
                     final String auth = episode.getPodcast().getAuthorization();

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
@@ -369,7 +369,7 @@ public class PlayEpisodeService extends Service implements OnPreparedListener,
                     // We add some request headers to overwrite the default user
                     // agent because this is blocked by some servers
                     final HashMap<String, String> headers = new HashMap<>(2);
-                    headers.put(Podcatcher.USER_AGENT_KEY, Podcatcher.USER_AGENT_VALUE);
+                    headers.put(Podcatcher.USER_AGENT_KEY, Podcatcher.userAgentValue);
 
                     // Also set the authorization header data if needed
                     final String auth = episode.getPodcast().getAuthorization();

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/view/fragments/PlayerFragment.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/view/fragments/PlayerFragment.java
@@ -18,7 +18,6 @@
 
 package com.podcatcher.deluxe.view.fragments;
 
-import com.podcatcher.deluxe.Podcatcher;
 import com.podcatcher.deluxe.R;
 import com.podcatcher.deluxe.listeners.PlayerListener;
 import com.podcatcher.deluxe.model.ParserUtils;
@@ -130,7 +129,7 @@ public class PlayerFragment extends Fragment {
     /**
      * Delay in between rewind or forward call-backs
      */
-    private static long TRANSPORT_DELAY = 500;
+    private static long transportDelay = 500;
     /**
      * The rewind runnable
      */
@@ -141,7 +140,7 @@ public class PlayerFragment extends Fragment {
             listener.onRewind();
 
             if (rewindButton.isPressed())
-                transportationHandler.postDelayed(rewindRunnable, TRANSPORT_DELAY);
+                transportationHandler.postDelayed(rewindRunnable, transportDelay);
         }
     };
     /**
@@ -154,7 +153,7 @@ public class PlayerFragment extends Fragment {
             listener.onFastForward();
 
             if (forwardButton.isPressed())
-                transportationHandler.postDelayed(forwardRunnable, TRANSPORT_DELAY);
+                transportationHandler.postDelayed(forwardRunnable, transportDelay);
         }
     };
 

--- a/app/src/deluxe/java/com/podcatcher/deluxe/adapters/PreferredDownloadFolderAdapter.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/adapters/PreferredDownloadFolderAdapter.java
@@ -74,8 +74,8 @@ public class PreferredDownloadFolderAdapter extends PodcatcherBaseAdapter {
         SDCARD_APP;
 
         // Potential prefixes and paths to the external sd card
-        private static String[] SD_CARD_PREFIXES = {"/storage/", "/mnt/", ""};
-        private static String[] SD_CARD_PATH_CANDIDATES = {
+        private static String[] sdCardPrefixes = {"/storage/", "/mnt/", ""};
+        private static String[] sdCardPathCandidates = {
                 "ext_sd", "external", "external_sd", "extSdCard",
                 "sdcard1", "sdcard2", "sdcard/ext_sd", "sdcard/external_sd"};
 
@@ -105,8 +105,8 @@ public class PreferredDownloadFolderAdapter extends PodcatcherBaseAdapter {
                     } else return internalAppFolder;
                 case SDCARD:
                     // Check all paths and select the first that exists
-                    for (String prefix : SD_CARD_PREFIXES)
-                        for (String path : SD_CARD_PATH_CANDIDATES) {
+                    for (String prefix : sdCardPrefixes)
+                        for (String path : sdCardPathCandidates) {
                             final File sdCardRoot = new File(prefix + path);
                             final File sdCardPodcasts = new File(sdCardRoot, "Podcasts");
 

--- a/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/PlayerFragment.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/PlayerFragment.java
@@ -141,7 +141,7 @@ public class PlayerFragment extends Fragment {
     /**
      * Delay in between rewind or forward call-backs
      */
-    private static long TRANSPORT_DELAY = 500;
+    private static long transportDelay = 500;
     /**
      * The rewind runnable
      */
@@ -152,7 +152,7 @@ public class PlayerFragment extends Fragment {
             listener.onRewind();
 
             if (rewindButton.isPressed())
-                transportationHandler.postDelayed(rewindRunnable, TRANSPORT_DELAY);
+                transportationHandler.postDelayed(rewindRunnable, transportDelay);
         }
     };
     /**
@@ -165,7 +165,7 @@ public class PlayerFragment extends Fragment {
             listener.onFastForward();
 
             if (forwardButton.isPressed())
-                transportationHandler.postDelayed(forwardRunnable, TRANSPORT_DELAY);
+                transportationHandler.postDelayed(forwardRunnable, transportDelay);
         }
     };
 

--- a/app/src/main/java/com/podcatcher/deluxe/ConfigureGpodderSyncActivity.java
+++ b/app/src/main/java/com/podcatcher/deluxe/ConfigureGpodderSyncActivity.java
@@ -29,7 +29,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 
 import static com.podcatcher.deluxe.BuildConfig.DEBUG;
-import static com.podcatcher.deluxe.Podcatcher.USER_AGENT_VALUE;
+import static com.podcatcher.deluxe.Podcatcher.userAgentValue;
 
 /**
  * Non-UI activity to configure the gpodder synchronization settings.
@@ -77,7 +77,7 @@ public class ConfigureGpodderSyncActivity extends BaseActivity implements
         this.authCheckTask = new AsyncTask<Void, Void, Void>() {
             @Override
             protected Void doInBackground(Void... params) {
-                if (!new GpodderClient(username, password, USER_AGENT_VALUE, DEBUG).authenticate())
+                if (!new GpodderClient(username, password, userAgentValue, DEBUG).authenticate())
                     cancel(true);
 
                 return null;

--- a/app/src/main/java/com/podcatcher/deluxe/ConfigurePodcareSyncActivity.java
+++ b/app/src/main/java/com/podcatcher/deluxe/ConfigurePodcareSyncActivity.java
@@ -38,7 +38,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import static com.podcatcher.deluxe.BuildConfig.DEBUG;
-import static com.podcatcher.deluxe.Podcatcher.USER_AGENT_VALUE;
+import static com.podcatcher.deluxe.Podcatcher.userAgentValue;
 
 /**
  * Non-UI activity to configure the Podcare synchronization settings.
@@ -59,7 +59,7 @@ public class ConfigurePodcareSyncActivity extends BaseActivity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        this.podcare = new PodcareClient(getString(R.string.podcare_api_key), USER_AGENT_VALUE, DEBUG);
+        this.podcare = new PodcareClient(getString(R.string.podcare_api_key), userAgentValue, DEBUG);
 
         if (savedInstanceState == null) {
             // Toggle link/unlink depending on current state

--- a/app/src/main/java/com/podcatcher/deluxe/Podcatcher.java
+++ b/app/src/main/java/com/podcatcher/deluxe/Podcatcher.java
@@ -64,7 +64,7 @@ public class Podcatcher extends Application {
     /**
      * The user agent string we use to identify us
      */
-    public static String USER_AGENT_VALUE;
+    public static String userAgentValue;
     /**
      * The http request header field key for the authorization
      */
@@ -95,7 +95,7 @@ public class Podcatcher extends Application {
         super.onCreate();
 
         // First things first, set-up user agent
-        USER_AGENT_VALUE = String.format("%1$s/%2$s", getString(R.string.app_name), VERSION_NAME);
+        userAgentValue = String.format("%1$s/%2$s", getString(R.string.app_name), VERSION_NAME);
 
         Picasso.with(this).setIndicatorsEnabled(BuildConfig.DEBUG);
 

--- a/app/src/main/java/com/podcatcher/deluxe/model/sync/gpodder/GpodderBaseSyncController.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/sync/gpodder/GpodderBaseSyncController.java
@@ -73,7 +73,7 @@ abstract class GpodderBaseSyncController extends PreferenceSetSyncController {
         final String user = preferences.getString(USERNAME_KEY, "");
         final String password = preferences.getString(PASSWORD_KEY, "");
 
-        client = new GpodderClient(user, password, Podcatcher.USER_AGENT_VALUE, BuildConfig.DEBUG);
+        client = new GpodderClient(user, password, Podcatcher.userAgentValue, BuildConfig.DEBUG);
         deviceId = preferences.getString(DEVICE_ID_KEY, getDefaultDeviceId(context));
     }
 

--- a/app/src/main/java/com/podcatcher/deluxe/model/sync/podcare/PodcareBaseSyncController.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/sync/podcare/PodcareBaseSyncController.java
@@ -25,7 +25,7 @@ import com.podcatcher.labs.sync.podcare.PodcareClient;
 import android.content.Context;
 
 import static com.podcatcher.deluxe.BuildConfig.DEBUG;
-import static com.podcatcher.deluxe.Podcatcher.USER_AGENT_VALUE;
+import static com.podcatcher.deluxe.Podcatcher.userAgentValue;
 
 /**
  * A sync controller for the Podcare service, abstract base class.
@@ -58,7 +58,7 @@ abstract class PodcareBaseSyncController extends PreferenceSetSyncController {
     protected PodcareBaseSyncController(Context context) {
         super(context);
 
-        podcare = new PodcareClient(context.getString(R.string.podcare_api_key), USER_AGENT_VALUE, DEBUG);
+        podcare = new PodcareClient(context.getString(R.string.podcare_api_key), userAgentValue, DEBUG);
         connectId = preferences.getString(CONNECT_ID_KEY, null);
     }
 }

--- a/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/DownloadEpisodeTask.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/DownloadEpisodeTask.java
@@ -55,7 +55,7 @@ import static android.app.DownloadManager.STATUS_FAILED;
 import static android.app.DownloadManager.STATUS_SUCCESSFUL;
 import static com.podcatcher.deluxe.Podcatcher.AUTHORIZATION_KEY;
 import static com.podcatcher.deluxe.Podcatcher.USER_AGENT_KEY;
-import static com.podcatcher.deluxe.Podcatcher.USER_AGENT_VALUE;
+import static com.podcatcher.deluxe.Podcatcher.userAgentValue;
 import static com.podcatcher.deluxe.model.tasks.remote.DownloadEpisodeTask.EpisodeDownloadError.BAD_EPISODE;
 import static com.podcatcher.deluxe.model.tasks.remote.DownloadEpisodeTask.EpisodeDownloadError.DESTINATION_NOT_WRITABLE;
 import static com.podcatcher.deluxe.model.tasks.remote.DownloadEpisodeTask.EpisodeDownloadError.DOWNLOAD_APP_DISABLED;
@@ -209,7 +209,7 @@ public class DownloadEpisodeTask extends AsyncTask<Episode, Long, Void> {
                         .setTitle(episode.getName())
                         .setDescription(episode.getPodcast().getName())
                         .setNotificationVisibility(Request.VISIBILITY_VISIBLE)
-                        .addRequestHeader(USER_AGENT_KEY, USER_AGENT_VALUE)
+                        .addRequestHeader(USER_AGENT_KEY, userAgentValue)
                         .addRequestHeader("Cache-Control", "no-store")
                         .setAllowedNetworkTypes(NETWORK_WIFI | (wifiOnly ? 0 : NETWORK_MOBILE))
                         .setAllowedOverRoaming(!wifiOnly);

--- a/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/LoadRemoteFileTask.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/LoadRemoteFileTask.java
@@ -30,7 +30,7 @@ import java.net.URL;
 
 import static com.podcatcher.deluxe.Podcatcher.AUTHORIZATION_KEY;
 import static com.podcatcher.deluxe.Podcatcher.USER_AGENT_KEY;
-import static com.podcatcher.deluxe.Podcatcher.USER_AGENT_VALUE;
+import static com.podcatcher.deluxe.Podcatcher.userAgentValue;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 /**
@@ -115,7 +115,7 @@ public abstract class LoadRemoteFileTask<Params, Result> extends
         // We set a custom user agent here because some servers (e.g. ZDF.de)
         // redirect connections from mobile devices to servers where the content
         // we are looking for might not be available.
-        connection.setRequestProperty(USER_AGENT_KEY, USER_AGENT_VALUE);
+        connection.setRequestProperty(USER_AGENT_KEY, userAgentValue);
         // Set cache control directive
         if (maxStale >= 0)
             connection.addRequestProperty("Cache-Control", "max-stale=" + maxStale);

--- a/app/src/videoDeluxe/java/com/podcatcher/deluxe/MxPlayerFullscreenVideoActivity.java
+++ b/app/src/videoDeluxe/java/com/podcatcher/deluxe/MxPlayerFullscreenVideoActivity.java
@@ -139,7 +139,7 @@ public class MxPlayerFullscreenVideoActivity extends BaseActivity {
         final List<String> headers = new ArrayList<>(4);
 
         headers.add(Podcatcher.USER_AGENT_KEY);
-        headers.add(Podcatcher.USER_AGENT_VALUE);
+        headers.add(Podcatcher.userAgentValue);
 
         // Put username and password if needed
         final String auth = episode.getPodcast().getAuthorization();

--- a/app/src/videoDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
+++ b/app/src/videoDeluxe/java/com/podcatcher/deluxe/services/PlayEpisodeService.java
@@ -469,7 +469,7 @@ public class PlayEpisodeService extends Service implements MediaPlayerControl,
                     // We add some request headers to overwrite the default user
                     // agent because this is blocked by some servers
                     final HashMap<String, String> headers = new HashMap<>(2);
-                    headers.put(Podcatcher.USER_AGENT_KEY, Podcatcher.USER_AGENT_VALUE);
+                    headers.put(Podcatcher.USER_AGENT_KEY, Podcatcher.userAgentValue);
 
                     // Also set the authorization header data if needed
                     final String auth = episode.getPodcast().getAuthorization();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S3008 Static non-final field names should comply with a naming convention

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S3008

Please let me know if you have any questions.

Zeeshan Asghar
