### PR TITLE
Methods should not be empty

### DIFF
--- a/app/src/androidTest/java/com/podcatcher/deluxe/model/tasks/remote/test/LoadPodcastTaskTest.java
+++ b/app/src/androidTest/java/com/podcatcher/deluxe/model/tasks/remote/test/LoadPodcastTaskTest.java
@@ -212,6 +212,7 @@ public class LoadPodcastTaskTest extends InstrumentationTestCase {
 
         @Override
         public void onPodcastLoadProgress(Podcast podcast, Progress progress) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/app/src/androidTest/java/com/podcatcher/deluxe/model/test/Utils.java
+++ b/app/src/androidTest/java/com/podcatcher/deluxe/model/test/Utils.java
@@ -81,6 +81,7 @@ public class Utils {
 
             @Override
             public void onPodcastLoadProgress(Podcast podcast, Progress progress) {
+                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/app/src/audioDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/audioDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -493,6 +493,7 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
 
     @Override
     public void onSyncStarted() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -430,6 +430,7 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
 
     @Override
     public void onSyncStarted() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/SwipeReorderListViewTouchListener.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/SwipeReorderListViewTouchListener.java
@@ -143,6 +143,7 @@ public class SwipeReorderListViewTouchListener implements View.OnTouchListener {
 
             @Override
             public void onScroll(AbsListView absListView, int i, int i1, int i2) {
+                throw new UnsupportedOperationException();
             }
         };
     }

--- a/app/src/main/java/com/podcatcher/deluxe/view/fragments/GpodderSyncConfigFragment.java
+++ b/app/src/main/java/com/podcatcher/deluxe/view/fragments/GpodderSyncConfigFragment.java
@@ -165,10 +165,12 @@ public class GpodderSyncConfigFragment extends DialogFragment {
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
+                throw new UnsupportedOperationException();
             }
 
             @Override
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/app/src/videoDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/videoDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -495,6 +495,7 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
 
     @Override
     public void onSyncStarted() {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1186 Methods should not be empty

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1186

Please let me know if you have any questions.

Zeeshan Asghar
