### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/app/src/audioDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/audioDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -107,8 +107,8 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
         // know then, whether the list is actually empty). Also do not show it
         // if we are given an URL in the intent, because this will trigger the
         // dialog anyway.
-        isInitialAppStart = (savedInstanceState == null);
-        hasPodcastToAdd = (getIntent().getData() != null);
+        isInitialAppStart = savedInstanceState == null;
+        hasPodcastToAdd = getIntent().getData() != null;
         needsUiUpdateOnResume = !isInitialAppStart;
         // Check if podcast list is available - if so, set it
         List<Podcast> podcastList = podcastManager.getPodcastList();

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/EpisodeListActivity.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/EpisodeListActivity.java
@@ -479,7 +479,7 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
             // Load in progress
         else
             contentSpinner.setSubtitle(getResources().getQuantityString(R.plurals.podcast_load_multiple_progress,
-                    podcastCount, (podcastCount - loadingPodcastCount), podcastCount));
+                    podcastCount, podcastCount - loadingPodcastCount, podcastCount));
     }
 
     /**

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -97,8 +97,8 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
         // know then, whether the list is actually empty). Also do not show it
         // if we are given an URL in the intent, because this will trigger the
         // dialog anyway.
-        isInitialAppStart = (savedInstanceState == null);
-        hasPodcastToAdd = (getIntent().getData() != null);
+        isInitialAppStart = savedInstanceState == null;
+        hasPodcastToAdd = getIntent().getData() != null;
         needsUiUpdateOnResume = !isInitialAppStart;
         // Check if podcast list is available - if so, set it
         List<Podcast> podcastList = podcastManager.getPodcastList();

--- a/app/src/audioSimple/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
@@ -139,7 +139,7 @@ public class EpisodeListFragment extends PodcatcherListFragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        refreshLayout = ((SwipeRefreshLayout) view.findViewById(R.id.episode_list_swipe_refresh));
+        refreshLayout = (SwipeRefreshLayout) view.findViewById(R.id.episode_list_swipe_refresh);
         refreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {

--- a/app/src/deluxe/java/com/podcatcher/deluxe/EpisodeListActivity.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/EpisodeListActivity.java
@@ -657,7 +657,7 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
             // Load in progress
         else
             contentSpinner.setSubtitle(getResources().getQuantityString(R.plurals.podcast_load_multiple_progress,
-                    podcastCount, (podcastCount - loadingPodcastCount), podcastCount));
+                    podcastCount, podcastCount - loadingPodcastCount, podcastCount));
     }
 
     /**

--- a/app/src/deluxe/java/com/podcatcher/deluxe/model/EpisodeStateManager.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/model/EpisodeStateManager.java
@@ -100,7 +100,7 @@ public abstract class EpisodeStateManager extends EpisodePlaylistManager impleme
             } // Metadata available
             else if (meta != null)
                 // We do not need to set this if false, simply remove the record
-                meta.isOld = (isOld != null && isOld ? true : null);
+                meta.isOld = isOld != null && isOld ? true : null;
 
             // We need to add the podcast URL to decide whether this meta
             // information is still needed later (Once the podcast feed is

--- a/app/src/deluxe/java/com/podcatcher/deluxe/model/sync/dropbox/DropboxEpisodeMetadataSyncController.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/model/sync/dropbox/DropboxEpisodeMetadataSyncController.java
@@ -142,7 +142,7 @@ abstract class DropboxEpisodeMetadataSyncController extends DropboxPodcastListSy
                 long localValue = episodeManager.getResumeAt(episode);
                 // If the local value is zero, it means the same as reset in the
                 // Dropbox sync controller context, so rewrite
-                localValue = (localValue == 0 ? RESUME_AT_RESET : localValue);
+                localValue = localValue == 0 ? RESUME_AT_RESET : localValue;
 
                 if (localValue != remoteValue)
                     episodeManager.setResumeAt(episode,
@@ -216,7 +216,7 @@ abstract class DropboxEpisodeMetadataSyncController extends DropboxPodcastListSy
         try {
             // Find and alter record for given episode as needed
             final DbxRecord episodeRecord = findAndPrepareRecord(episode);
-            final long newValue = (millis == null ? RESUME_AT_RESET : millis);
+            final long newValue = millis == null ? RESUME_AT_RESET : millis;
             // Only write to the record if the data actually changed
             if (!episodeRecord.hasField(EPISODE_RESUME_AT) ||
                     episodeRecord.getLong(EPISODE_RESUME_AT) != newValue)

--- a/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/EpisodeListFragment.java
@@ -192,7 +192,7 @@ public class EpisodeListFragment extends PodcatcherListFragment implements Reord
         infoBoxTextView = (TextView) view.findViewById(R.id.info_box);
         infoBoxDivider = view.findViewById(R.id.info_box_divider);
 
-        refreshLayout = ((SwipeRefreshLayout) view.findViewById(R.id.episode_list_swipe_refresh));
+        refreshLayout = (SwipeRefreshLayout) view.findViewById(R.id.episode_list_swipe_refresh);
         refreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {

--- a/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/SwipeReorderListViewTouchListener.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/view/fragments/SwipeReorderListViewTouchListener.java
@@ -279,7 +279,7 @@ public class SwipeReorderListViewTouchListener implements View.OnTouchListener {
                 float deltaY = motionEvent.getRawY() - mDownY;
                 if (Math.abs(deltaX) > mSlop && Math.abs(deltaY) < Math.abs(deltaX) / 2) {
                     mSwiping = true;
-                    mSwipingSlop = (deltaX > 0 ? mSlop : -mSlop);
+                    mSwipingSlop = deltaX > 0 ? mSlop : -mSlop;
                     mListView.requestDisallowInterceptTouchEvent(true);
 
                     // Cancel ListView's touch (un-highlighting the item)

--- a/app/src/videoDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
+++ b/app/src/videoDeluxe/java/com/podcatcher/deluxe/PodcastActivity.java
@@ -107,8 +107,8 @@ public class PodcastActivity extends EpisodeListActivity implements OnBackStackC
         // know then, whether the list is actually empty). Also do not show it
         // if we are given an URL in the intent, because this will trigger the
         // dialog anyway.
-        isInitialAppStart = (savedInstanceState == null);
-        hasPodcastToAdd = (getIntent().getData() != null);
+        isInitialAppStart = savedInstanceState == null;
+        hasPodcastToAdd = getIntent().getData() != null;
         needsUiUpdateOnResume = !isInitialAppStart;
         // Check if podcast list is available - if so, set it
         List<Podcast> podcastList = podcastManager.getPodcastList();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Zeeshan Asghar
