### PR TITLE
Unused private fields should be removed

### DIFF
--- a/app/src/androidTest/java/com/podcatcher/deluxe/model/test/EpisodeDownloadManagerTest.java
+++ b/app/src/androidTest/java/com/podcatcher/deluxe/model/test/EpisodeDownloadManagerTest.java
@@ -27,8 +27,6 @@ import static com.podcatcher.deluxe.model.EpisodeDownloadManager.sanitizeAsFileP
 @SuppressWarnings("javadoc")
 public class EpisodeDownloadManagerTest extends InstrumentationTestCase {
 
-    private static final String RESERVED_CHARS = "|\\?*<\":>+[]/'#!,&";
-
     public final void testSanitize() {
         // assertEquals("", sanitizeAsFilePath("", "", ""));
 

--- a/app/src/androidTest/java/com/podcatcher/deluxe/model/test/SuggestionImporter.java
+++ b/app/src/androidTest/java/com/podcatcher/deluxe/model/test/SuggestionImporter.java
@@ -203,17 +203,9 @@ public class SuggestionImporter extends InstrumentationTestCase {
 
         // Field will be access via GSON reflection
         private String title;
-        private String subtitle;
-        private String keywords;
-        private String feed;
-        private String logo;
-        private String site;
-        private String description;
         private Object[] category;
         private String language;
         private String type;
-        private String explicit;
-        private int votes;
         private String path;
 
         public JsonDummy(SuggestionImport si) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1068 Unused private fields should be removed

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1068 

Please let me know if you have any questions.

Zeeshan Asghar
