### PR TITLE
Switch cases should end with an unconditional 'break' statement

### DIFF
--- a/app/src/audioSimple/java/com/podcatcher/deluxe/EpisodeListActivity.java
+++ b/app/src/audioSimple/java/com/podcatcher/deluxe/EpisodeListActivity.java
@@ -158,6 +158,8 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
             case SMALL_PORTRAIT:
                 // This case should be handled by sub-classes
                 break;
+            default:
+                break;
         }
     }
 
@@ -197,6 +199,8 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
                 break;
             case SMALL_PORTRAIT:
                 // This case should be handled by sub-classes
+                break;
+            default:
                 break;
         }
     }
@@ -243,6 +247,8 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
                 break;
             case SMALL_PORTRAIT:
                 // This case should be handled by sub-classes
+                break;
+            default:
                 break;
         }
     }

--- a/app/src/deluxe/java/com/podcatcher/deluxe/EpisodeListActivity.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/EpisodeListActivity.java
@@ -188,6 +188,8 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
             case SMALL_PORTRAIT:
                 // This case should be handled by sub-classes
                 break;
+            default:
+                break;
         }
     }
 
@@ -230,6 +232,8 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
                 break;
             case SMALL_PORTRAIT:
                 // This case should be handled by sub-classes
+                break;
+            default:
                 break;
         }
     }
@@ -278,6 +282,8 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
             case SMALL_PORTRAIT:
                 // This case should be handled by sub-classes
                 break;
+            default:
+                break;
         }
     }
 
@@ -314,6 +320,8 @@ public abstract class EpisodeListActivity extends EpisodeActivity implements
                 break;
             case SMALL_PORTRAIT:
                 // This case should be handled by sub-classes
+                break;
+            default:
                 break;
         }
     }

--- a/app/src/main/java/com/podcatcher/deluxe/model/types/Podcast.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/types/Podcast.java
@@ -632,6 +632,8 @@ public class Podcast extends FeedEntity implements Comparable<Podcast> {
                     case RSS.ITEM:
                         parseAndAddEpisode(parser, episodes, episodeIndex++);
                         break;
+                    default:
+                        break;
                 }
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S128 Switch cases should end with an unconditional 'break' statement

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S128 

Please let me know if you have any questions.

Zeeshan Asghar
