### PR TITLE
'private' methods that don't access instance data should be static

### DIFF
--- a/app/src/androidTest/java/com/podcatcher/deluxe/model/types/test/EpisodeTest.java
+++ b/app/src/androidTest/java/com/podcatcher/deluxe/model/types/test/EpisodeTest.java
@@ -66,7 +66,7 @@ public class EpisodeTest extends InstrumentationTestCase {
         assertTrue(dateOkay(e.parsePubDate("Sun, 10 Nov 2013 00:00:00 -0600")));
     }
 
-    private boolean dateOkay(Date date) {
+    private static boolean dateOkay(Date date) {
 
         return date != null &&
                 // No more then 10 years back

--- a/app/src/deluxe/java/com/podcatcher/deluxe/model/sync/podcare/PodcareEpisodeMetadataSyncController.java
+++ b/app/src/deluxe/java/com/podcatcher/deluxe/model/sync/podcare/PodcareEpisodeMetadataSyncController.java
@@ -246,7 +246,7 @@ abstract class PodcareEpisodeMetadataSyncController extends PodcarePodcastListSy
         return result;
     }
 
-    private String formatTime(int time) {
+    private static String formatTime(int time) {
         final int hours = time / 3600;
         return String.format(Locale.US, "%02d:%02d:%02d", hours, (time / 60) - 60 * hours, time % 60);
     }

--- a/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/DownloadEpisodeTask.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/DownloadEpisodeTask.java
@@ -367,7 +367,7 @@ public class DownloadEpisodeTask extends AsyncTask<Episode, Long, Void> {
         listener.onEpisodeDownloadFailed(episode, downloadError);
     }
 
-    private boolean moveFile(File from, File to) {
+    private static boolean moveFile(File from, File to) {
         boolean success = true;
 
         BufferedInputStream reader = null;

--- a/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/LoadPodcastTask.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/LoadPodcastTask.java
@@ -316,7 +316,7 @@ public class LoadPodcastTask extends LoadRemoteFileTask<Podcast, Void> {
             listener.onPodcastLoadFailed(podcast, errorCode);
     }
 
-    private byte[] removeLeadingWhitespaces(byte[] byteArray) {
+    private static byte[] removeLeadingWhitespaces(byte[] byteArray) {
         int firstNonWhiteSpacePosition = 0;
 
         // Trailing whitespaces make the XML pull parser fail, remove them

--- a/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/LoadSuggestionsTask.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/tasks/remote/LoadSuggestionsTask.java
@@ -300,7 +300,7 @@ public class LoadSuggestionsTask extends LoadRemoteFileTask<Void, List<Suggestio
         return suggestion;
     }
 
-    private boolean isRecentDate(String dateAdded) {
+    private static boolean isRecentDate(String dateAdded) {
         try {
             return DATE_FORMATTER.parse(dateAdded).after(RECENT_LIMIT);
         } catch (ParseException e) {
@@ -366,7 +366,7 @@ public class LoadSuggestionsTask extends LoadRemoteFileTask<Void, List<Suggestio
         }
     }
 
-    private byte[] readFileToByteArray(InputStream stream) throws IOException {
+    private static byte[] readFileToByteArray(InputStream stream) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
         int nRead;

--- a/app/src/main/java/com/podcatcher/deluxe/model/types/Episode.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/types/Episode.java
@@ -389,12 +389,12 @@ public class Episode extends FeedEntity implements Comparable<Episode> {
         parser.nextText();
     }
 
-    private String parseMediaType(String attributeValue) {
+    private static String parseMediaType(String attributeValue) {
         return attributeValue != null && attributeValue.trim().length() > 0 ?
                 attributeValue.trim().toLowerCase(Locale.US) : null;
     }
 
-    private int parseFileSize(String attributeValue) {
+    private static int parseFileSize(String attributeValue) {
         try {
             return Integer.valueOf(attributeValue);
         } catch (NumberFormatException | NullPointerException ne) {

--- a/app/src/main/java/com/podcatcher/deluxe/model/types/Podcast.java
+++ b/app/src/main/java/com/podcatcher/deluxe/model/types/Podcast.java
@@ -463,7 +463,7 @@ public class Podcast extends FeedEntity implements Comparable<Podcast> {
         return collator.compare(nameMe, nameAnother);
     }
 
-    private String prepareCompare(String feedLabel) {
+    private static String prepareCompare(String feedLabel) {
         // This will determine the sorting for some special cases
         switch (feedLabel.toLowerCase(Locale.ENGLISH)) {
             case "audio":


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2325 'private' methods that don't access instance data should be 'static'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2325 

Please let me know if you have any questions.

Zeeshan Asghar
